### PR TITLE
fix: pass `customer_id` in `delete_document()`

### DIFF
--- a/src/vectara/__init__.py
+++ b/src/vectara/__init__.py
@@ -436,6 +436,7 @@ class Vectara():
             headers["Authorization"] = f"Bearer {self.jwt_token}"
 
         payload = {
+            "customerId": self.customer_id,
             "corpusId": corpus_id,
             "documentId": doc_id
         }


### PR DESCRIPTION
Without `customer_id`, deletion will fail